### PR TITLE
지도에서 채팅방 찾는 화면 data, domain 모듈 구현, 채팅방 목록 화면 수정

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,9 +75,6 @@ dependencies {
     implementation 'com.firebaseui:firebase-ui-auth:7.2.0' //파이어베이스 인증 2
     implementation 'com.google.firebase:firebase-firestore-ktx:24.4.0' //파이어스토어
 
-
-    implementation 'com.google.firebase:firebase-firestore-ktx:24.4.0'
-
     // Glide
     implementation 'com.github.bumptech.glide:glide:4.14.2'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.14.2'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -76,6 +76,8 @@ dependencies {
     implementation 'com.google.firebase:firebase-firestore-ktx:24.4.0' //파이어스토어
 
 
+    implementation 'com.google.firebase:firebase-firestore-ktx:24.4.0'
+
     // Glide
     implementation 'com.github.bumptech.glide:glide:4.14.2'
     annotationProcessor 'com.github.bumptech.glide:compiler:4.14.2'

--- a/app/src/main/java/com/kiwi/kiwitalk/AppPreference.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/AppPreference.kt
@@ -6,12 +6,11 @@ import javax.inject.Singleton
 
 @Singleton
 class AppPreference @Inject constructor(private val prefs: SharedPreferences) {
-
-    fun getString(key: String, defValue: String): String{
-        return prefs.getString(key, defValue)?:defValue
+    fun getString(key: String, defValue: String): String {
+        return prefs.getString(key, defValue) ?: defValue
     }
 
-    fun setString(key: String, value: String){
+    fun setString(key: String, value: String) {
         prefs.edit().putString(key, value).apply()
     }
 }

--- a/app/src/main/java/com/kiwi/kiwitalk/Const.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/Const.kt
@@ -4,4 +4,6 @@ object Const {
     const val LOGIN_HISTORY_KEY = "login_history_key"
     const val EMPTY_STRING = ""
     const val SERVER_CLIENT_ID_KEY = "SERVER_CLIENT_ID"
+    const val MAP_KEY_KEYWORD = "keyword"
+    const val MAP_KEY_COUNTRY = "country"
 }

--- a/app/src/main/java/com/kiwi/kiwitalk/KiwiApplication.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/KiwiApplication.kt
@@ -4,6 +4,5 @@ import android.app.Application
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
-class KiwiApplication: Application() {
-
+class KiwiApplication : Application() {
 }

--- a/app/src/main/java/com/kiwi/kiwitalk/di/ApplicationModule.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/di/ApplicationModule.kt
@@ -15,7 +15,6 @@ import javax.inject.Singleton
 class ApplicationModule {
     @Singleton
     @Provides
-    fun providePreference(@ApplicationContext context: Context): AppPreference
-        = AppPreference(context.getSharedPreferences(Const.LOGIN_HISTORY_KEY, Context.MODE_PRIVATE))
-
+    fun providePreference(@ApplicationContext context: Context): AppPreference =
+        AppPreference(context.getSharedPreferences(Const.LOGIN_HISTORY_KEY, Context.MODE_PRIVATE))
 }

--- a/app/src/main/java/com/kiwi/kiwitalk/di/ChatModule.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/di/ChatModule.kt
@@ -33,4 +33,9 @@ class ChatModule {
             config = Config(),
             appContext = context,
         )
+
+    @Provides
+    @Singleton
+    fun provideFirestoreClient(): FirebaseFirestore =
+        Firebase.firestore
 }

--- a/app/src/main/java/com/kiwi/kiwitalk/di/ChatModule.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/di/ChatModule.kt
@@ -1,9 +1,6 @@
 package com.kiwi.kiwitalk.di
 
 import android.content.Context
-import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.firestore.ktx.firestore
-import com.google.firebase.ktx.Firebase
 import com.kiwi.kiwitalk.BuildConfig.STREAM_API_KEY
 import dagger.Module
 import dagger.Provides
@@ -33,9 +30,4 @@ class ChatModule {
             config = Config(),
             appContext = context,
         )
-
-    @Provides
-    @Singleton
-    fun provideFirestoreClient(): FirebaseFirestore =
-        Firebase.firestore
 }

--- a/app/src/main/java/com/kiwi/kiwitalk/di/ChatModule.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/di/ChatModule.kt
@@ -1,6 +1,9 @@
 package com.kiwi.kiwitalk.di
 
 import android.content.Context
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
 import com.kiwi.kiwitalk.BuildConfig.STREAM_API_KEY
 import dagger.Module
 import dagger.Provides

--- a/app/src/main/java/com/kiwi/kiwitalk/di/FirebaseModule.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/di/FirebaseModule.kt
@@ -12,11 +12,9 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 class FirebaseModule {
-
     @Provides
     @Singleton
-    fun provideFireStore(): FirebaseFirestore{
+    fun provideFireStore(): FirebaseFirestore {
         return Firebase.firestore
     }
-
 }

--- a/app/src/main/java/com/kiwi/kiwitalk/di/RepositoryModule.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/di/RepositoryModule.kt
@@ -15,7 +15,6 @@ import javax.inject.Singleton
 @Module
 @InstallIn(SingletonComponent::class)
 abstract class RepositoryModule {
-
     @Singleton
     @Binds //Interface 주입, abstract 사용
     abstract fun bindsSearchChatRepository(repository: SearchChatRepositoryImpl): SearchChatRepository

--- a/app/src/main/java/com/kiwi/kiwitalk/di/RepositoryModule.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/di/RepositoryModule.kt
@@ -1,5 +1,7 @@
 package com.kiwi.kiwitalk.di
 
+import com.kiwi.data.datasource.remote.SearchChatRemoteDataSource
+import com.kiwi.data.datasource.remote.SearchChatRemoteDataSourceImpl
 import com.kiwi.data.repository.SearchChatRepositoryImpl
 import com.kiwi.data.repository.SearchKeywordRepositoryImpl
 import com.kiwi.domain.repository.SearchChatRepository
@@ -17,6 +19,10 @@ abstract class RepositoryModule {
     @Singleton
     @Binds //Interface 주입, abstract 사용
     abstract fun bindsSearchChatRepository(repository: SearchChatRepositoryImpl): SearchChatRepository
+
+    @Singleton
+    @Binds
+    abstract fun bindsSearchChatRemoteDataSource(dataSource: SearchChatRemoteDataSourceImpl): SearchChatRemoteDataSource
 
     @Binds
     @Singleton

--- a/app/src/main/java/com/kiwi/kiwitalk/ui/BindingAdapter.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/BindingAdapter.kt
@@ -5,12 +5,13 @@ import androidx.databinding.BindingAdapter
 import com.bumptech.glide.Glide
 import com.kiwi.kiwitalk.R
 
-@BindingAdapter("image")
+@BindingAdapter("loadImageByUri")
 fun setImage(imageView: ImageView, uri: String?) {
     Glide.with(imageView.context)
         .load(uri)
         .placeholder(R.drawable.ic_launcher_background)
-        .error(R.drawable.ic_launcher_background)
+        .error(R.drawable.logo_splash_transparent)
         .fallback(R.drawable.ic_launcher_background)
+        .fitCenter()
         .into(imageView)
 }

--- a/app/src/main/java/com/kiwi/kiwitalk/ui/home/ChatListFragment.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/home/ChatListFragment.kt
@@ -44,8 +44,8 @@ class ChatListFragment : Fragment() {
 
     private fun initRecyclerView() {
         val adapter = ChatListViewAdapter()
-        adapter.onClickListener = object : ChatListViewAdapter.OnChatListClickListener {
-            override fun onChatListClick(channel: Channel) {
+        adapter.onClickListener = object : ChatListViewAdapter.OnChatClickListener {
+            override fun onChatClick(channel: Channel) {
                 startActivity(MessageListActivity.createIntent(requireContext(), channel.cid))
             }
         }
@@ -54,7 +54,7 @@ class ChatListFragment : Fragment() {
             if (it.channels.isEmpty()) {
                 binding.tvChatListEmpty.visibility = View.VISIBLE
                 binding.rvChatList.visibility = View.INVISIBLE
-            } else{
+            } else {
                 binding.tvChatListEmpty.visibility = View.INVISIBLE
                 binding.rvChatList.visibility = View.VISIBLE
                 adapter.submitList(it.channels)

--- a/app/src/main/java/com/kiwi/kiwitalk/ui/home/ChatListViewAdapter.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/home/ChatListViewAdapter.kt
@@ -6,15 +6,15 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.kiwi.kiwitalk.databinding.ChatListItemBinding
+import com.kiwi.kiwitalk.databinding.ChatItemBinding
 import io.getstream.chat.android.client.models.Channel
 
-class ChatListViewAdapter : ListAdapter<Channel, RecyclerView.ViewHolder>(ChatListDiffUtil) {
-    lateinit var onClickListener: OnChatListClickListener
+class ChatListViewAdapter : ListAdapter<Channel, RecyclerView.ViewHolder>(ChatDiffUtil) {
+    lateinit var onClickListener: OnChatClickListener
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
-        return ChatListViewHolder(
-            ChatListItemBinding.inflate(
+        return ChatViewHolder(
+            ChatItemBinding.inflate(
                 LayoutInflater.from(
                     parent.context
                 ), parent, false
@@ -24,30 +24,30 @@ class ChatListViewAdapter : ListAdapter<Channel, RecyclerView.ViewHolder>(ChatLi
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder) {
-            is ChatListViewHolder -> {
+            is ChatViewHolder -> {
                 holder.bind(getItem(position))
                 holder.itemView.setOnClickListener {
-                    onClickListener.onChatListClick(getItem(position))
+                    onClickListener.onChatClick(getItem(position))
                 }
             }
         }
 
     }
 
-    class ChatListViewHolder(private val binding: ChatListItemBinding) :
+    class ChatViewHolder(private val binding: ChatItemBinding) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(item: Channel) {
             Log.d("ChatListViewAdapter", "bind: ${item.image}")
-            binding.chatList = item
+            binding.chat = item
         }
     }
 
-    interface OnChatListClickListener {
-        fun onChatListClick(channel: Channel)
+    interface OnChatClickListener {
+        fun onChatClick(channel: Channel)
     }
 
     companion object {
-        val ChatListDiffUtil = object : DiffUtil.ItemCallback<Channel>() {
+        val ChatDiffUtil = object : DiffUtil.ItemCallback<Channel>() {
             override fun areItemsTheSame(oldItem: Channel, newItem: Channel): Boolean {
                 return oldItem.cid == newItem.cid
             }

--- a/app/src/main/java/com/kiwi/kiwitalk/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/login/LoginActivity.kt
@@ -1,8 +1,7 @@
 package com.kiwi.kiwitalk.ui.login
 
-import android.os.Build
 import android.content.Intent
-import androidx.appcompat.app.AppCompatActivity
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.View
@@ -12,6 +11,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.annotation.RequiresApi
+import androidx.appcompat.app.AppCompatActivity
 import com.google.android.gms.auth.api.Auth
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
@@ -64,7 +64,7 @@ class LoginActivity : AppCompatActivity() {
                     result ?: return@registerForActivityResult
                     if (result.isSuccess) {
                         val account = result.signInAccount
-                        viewModel.signIn(account?.idToken?: Const.EMPTY_STRING)
+                        viewModel.signIn(account?.idToken ?: Const.EMPTY_STRING)
                     }
                 } catch (e: Exception) {
                     Log.d("LoginResultFail", e.toString())
@@ -98,6 +98,7 @@ class LoginActivity : AppCompatActivity() {
 
     companion object {
         //const val SERVER_CLIENT_KEY = BuildConfig.SERVER_CLIENT_ID
-        const val SERVER_CLIENT_KEY = "611516619499-v3b7482t6qbldpn0ens6rgp45i6fo577.apps.googleusercontent.com"
+        const val SERVER_CLIENT_KEY =
+            "611516619499-v3b7482t6qbldpn0ens6rgp45i6fo577.apps.googleusercontent.com"
     }
 }

--- a/app/src/main/java/com/kiwi/kiwitalk/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/login/LoginViewModel.kt
@@ -43,7 +43,7 @@ class LoginViewModel @Inject constructor(
         /* 기타 토큰 유효성 검사 추가 */
     }
 
-    fun signOut(){
+    fun signOut() {
 
     }
 

--- a/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatViewModel.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatViewModel.kt
@@ -2,10 +2,10 @@ package com.kiwi.kiwitalk.ui.search
 
 import androidx.lifecycle.ViewModel
 import com.kiwi.domain.repository.SearchChatRepository
-import dagger.hilt.android.scopes.ViewModelScoped
+import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
-@ViewModelScoped
+@HiltViewModel
 class SearchChatViewModel @Inject constructor(
     private val searchChatRepository: SearchChatRepository
 ) : ViewModel() {

--- a/app/src/main/res/layout/activity_chatting.xml
+++ b/app/src/main/res/layout/activity_chatting.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -13,7 +13,6 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        />
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_new_chat.xml
+++ b/app/src/main/res/layout/activity_new_chat.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_search_chat.xml
+++ b/app/src/main/res/layout/activity_search_chat.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"

--- a/app/src/main/res/layout/chat_item.xml
+++ b/app/src/main/res/layout/chat_item.xml
@@ -8,7 +8,7 @@
         <import type="com.kiwi.kiwitalk.Const" />
 
         <variable
-            name="chatList"
+            name="chat"
             type="io.getstream.chat.android.client.models.Channel" />
     </data>
 
@@ -31,7 +31,7 @@
                 android:layout_marginBottom="6dp"
                 android:adjustViewBounds="true"
                 android:contentDescription="@string/img_chatList_profile_des"
-                app:loadImageByUri="@{chatList.image}"
+                app:loadImageByUri="@{chat.image}"
                 tools:src="@drawable/ic_launcher_background" />
 
             <TextView
@@ -39,21 +39,21 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:ellipsize="end"
-                android:text="@{chatList.name}"
+                android:text="@{chat.name}"
                 tools:text="방 제목" />
 
             <TextView
                 android:id="@+id/tv_country"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@{chatList.extraData.getOrDefault(Const.MAP_KEY_COUNTRY, `지역`).toString()}"
+                android:text="@{chat.extraData.getOrDefault(Const.MAP_KEY_COUNTRY, `지역`).toString()}"
                 tools:text="서울특별시 강남구" />
 
             <TextView
                 android:id="@+id/tv_keyword"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@{chatList.extraData.getOrDefault(Const.MAP_KEY_KEYWORD, `키워드`).toString()}"
+                android:text="@{chat.extraData.getOrDefault(Const.MAP_KEY_KEYWORD, `키워드`).toString()}"
                 tools:text="축구, 농구, 운동" />
 
         </androidx.appcompat.widget.LinearLayoutCompat>

--- a/app/src/main/res/layout/chat_list_item.xml
+++ b/app/src/main/res/layout/chat_list_item.xml
@@ -15,43 +15,42 @@
     <com.google.android.material.card.MaterialCardView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="5dp"
-        android:padding="5dp">
+        android:layout_margin="5dp">
 
         <androidx.appcompat.widget.LinearLayoutCompat
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:orientation="vertical"
+            android:padding="10dp">
 
             <ImageView
                 android:id="@+id/img_chatList_profile"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginVertical="8dp"
-                android:layout_marginStart="4dp"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginBottom="6dp"
                 android:adjustViewBounds="true"
                 android:contentDescription="@string/img_chatList_profile_des"
-                app:image="@{chatList.image}"
+                app:loadImageByUri="@{chatList.image}"
                 tools:src="@drawable/ic_launcher_background" />
 
             <TextView
                 android:id="@+id/tv_chat_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="8dp"
                 android:ellipsize="end"
                 android:text="@{chatList.name}"
                 tools:text="방 제목" />
 
             <TextView
-                android:id="@+id/tv_location"
+                android:id="@+id/tv_country"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@{chatList.extraData.getOrDefault(Const.MAP_KEY_COUNTRY, `지역`).toString()}"
                 tools:text="서울특별시 강남구" />
 
             <TextView
-                android:id="@+id/tv_tags"
+                android:id="@+id/tv_keyword"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@{chatList.extraData.getOrDefault(Const.MAP_KEY_KEYWORD, `키워드`).toString()}"

--- a/app/src/main/res/layout/chat_list_item.xml
+++ b/app/src/main/res/layout/chat_list_item.xml
@@ -5,6 +5,8 @@
 
     <data>
 
+        <import type="com.kiwi.kiwitalk.Const" />
+
         <variable
             name="chatList"
             type="io.getstream.chat.android.client.models.Channel" />
@@ -45,14 +47,14 @@
                 android:id="@+id/tv_location"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@{chatList.extraData.toString()}"
+                android:text="@{chatList.extraData.getOrDefault(Const.MAP_KEY_COUNTRY, `지역`).toString()}"
                 tools:text="서울특별시 강남구" />
 
             <TextView
                 android:id="@+id/tv_tags"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@{chatList.extraData.toString()}"
+                android:text="@{chatList.extraData.getOrDefault(Const.MAP_KEY_KEYWORD, `키워드`).toString()}"
                 tools:text="축구, 농구, 운동" />
 
         </androidx.appcompat.widget.LinearLayoutCompat>

--- a/app/src/main/res/layout/fragment_chat_list.xml
+++ b/app/src/main/res/layout/fragment_chat_list.xml
@@ -12,7 +12,7 @@
         android:layout_height="match_parent"
         app:layoutManager="androidx.recyclerview.widget.StaggeredGridLayoutManager"
         app:spanCount="2"
-        tools:listitem="@layout/chat_list_item" />
+        tools:listitem="@layout/chat_item" />
 
     <TextView
         android:id="@+id/tv_chatList_empty"

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <attr name="colorPrimaryLight" format="color"/>
-    <attr name="colorSurfaceDark" format="color"/>
-    <attr name="colorOnSurfaceLight" format="color"/>
+    <attr name="colorPrimaryLight" format="color" />
+    <attr name="colorSurfaceDark" format="color" />
+    <attr name="colorOnSurfaceLight" format="color" />
 </resources>

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
+    id 'com.google.gms.google-services'
 }
 
 android {
@@ -38,6 +39,10 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.4'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
+
+    // Firebase
+    implementation platform ('com.google.firebase:firebase-bom:31.0.3')
+    implementation 'com.google.firebase:firebase-firestore-ktx'
 
     // Inject(For Hilt)
     implementation "javax.inject:javax.inject:1"

--- a/data/google-services.json
+++ b/data/google-services.json
@@ -9,7 +9,7 @@
       "client_info": {
         "mobilesdk_app_id": "1:611516619499:android:e87f8919813f13e8e27cae",
         "android_client_info": {
-          "package_name": "com.kiwi.app"
+          "package_name": "com.kiwi.data"
         }
       },
       "oauth_client": [

--- a/data/src/main/java/com/kiwi/data/Const.kt
+++ b/data/src/main/java/com/kiwi/data/Const.kt
@@ -1,0 +1,5 @@
+package com.kiwi.data
+
+object Const {
+    const val CHAT_LIST_COLLECTION = "ChatList"
+}

--- a/data/src/main/java/com/kiwi/data/Const.kt
+++ b/data/src/main/java/com/kiwi/data/Const.kt
@@ -1,5 +1,5 @@
 package com.kiwi.data
 
 object Const {
-    const val CHAT_LIST_COLLECTION = "ChatList"
+    const val CHAT_COLLECTION = "Chat"
 }

--- a/data/src/main/java/com/kiwi/data/datasource/remote/SearchChatRemoteDataSource.kt
+++ b/data/src/main/java/com/kiwi/data/datasource/remote/SearchChatRemoteDataSource.kt
@@ -1,0 +1,11 @@
+package com.kiwi.data.datasource.remote
+
+import com.kiwi.data.model.remote.ChatInfoRemote
+import com.kiwi.data.model.remote.MarkerRemote
+import kotlinx.coroutines.flow.Flow
+
+interface SearchChatRemoteDataSource {
+    suspend fun getMarkerList(keyword: List<String>, x: Double, y: Double): Flow<MarkerRemote>
+
+    suspend fun getChat(cid: String): ChatInfoRemote
+}

--- a/data/src/main/java/com/kiwi/data/datasource/remote/SearchChatRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/kiwi/data/datasource/remote/SearchChatRemoteDataSourceImpl.kt
@@ -19,7 +19,8 @@ class SearchChatRemoteDataSourceImpl @Inject constructor(
         x: Double,
         y: Double
     ): Flow<MarkerRemote> = callbackFlow {
-        firestore.collection(Const.CHAT_LIST_COLLECTION).get()
+        //TODO: Chat 컬렉션의 모든 데이터를 가져오지 않고, 쿼리를 사용하도록 변경
+        firestore.collection(Const.CHAT_COLLECTION).get()
             .addOnSuccessListener {
                 Log.d("SearchChatRemoteImpl", "getMarkerList: ${it.documents}")
                 it.toObjects<MarkerRemote>().forEach { markerRemote ->

--- a/data/src/main/java/com/kiwi/data/datasource/remote/SearchChatRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/kiwi/data/datasource/remote/SearchChatRemoteDataSourceImpl.kt
@@ -1,0 +1,37 @@
+package com.kiwi.data.datasource.remote
+
+import android.util.Log
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.ktx.toObjects
+import com.kiwi.data.Const
+import com.kiwi.data.model.remote.ChatInfoRemote
+import com.kiwi.data.model.remote.MarkerRemote
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import javax.inject.Inject
+
+class SearchChatRemoteDataSourceImpl @Inject constructor(
+    private val firestore: FirebaseFirestore
+) : SearchChatRemoteDataSource {
+    override suspend fun getMarkerList(
+        keyword: List<String>,
+        x: Double,
+        y: Double
+    ): Flow<MarkerRemote> = callbackFlow {
+        firestore.collection(Const.CHAT_LIST_COLLECTION).get()
+            .addOnSuccessListener {
+                Log.d("SearchChatRemoteImpl", "getMarkerList: ${it.documents}")
+                it.toObjects<MarkerRemote>().forEach { markerRemote ->
+                    trySend(markerRemote)
+                }
+            }.addOnFailureListener {
+                Log.d("SearchChatRemoteImpl", "getMarkerList: $it")
+            }
+        awaitClose()
+    }
+
+    override suspend fun getChat(cid: String): ChatInfoRemote {
+        TODO("Not yet implemented")
+    }
+}

--- a/data/src/main/java/com/kiwi/data/mapper/Mapper.kt
+++ b/data/src/main/java/com/kiwi/data/mapper/Mapper.kt
@@ -1,0 +1,13 @@
+package com.kiwi.data.mapper
+
+import com.kiwi.data.model.remote.MarkerRemote
+import com.kiwi.domain.model.Marker
+
+object Mapper {
+    fun MarkerRemote.toMarker() = Marker(
+        cid = cid,
+        x = x,
+        y = y,
+        keywords = keywords
+    )
+}

--- a/data/src/main/java/com/kiwi/data/model/remote/ChatInfoRemote.kt
+++ b/data/src/main/java/com/kiwi/data/model/remote/ChatInfoRemote.kt
@@ -1,0 +1,5 @@
+package com.kiwi.data.model.remote
+
+data class ChatInfoRemote(
+    val cid: String
+)

--- a/data/src/main/java/com/kiwi/data/model/remote/MarkerRemote.kt
+++ b/data/src/main/java/com/kiwi/data/model/remote/MarkerRemote.kt
@@ -1,0 +1,8 @@
+package com.kiwi.data.model.remote
+
+data class MarkerRemote(
+    val cid: String = "",
+    val x: Double = .0,
+    val y: Double = .0,
+    val keywords: List<String> = emptyList()
+)

--- a/data/src/main/java/com/kiwi/data/repository/SearchChatRepositoryImpl.kt
+++ b/data/src/main/java/com/kiwi/data/repository/SearchChatRepositoryImpl.kt
@@ -1,16 +1,31 @@
 package com.kiwi.data.repository
 
+import android.util.Log
+import com.kiwi.data.datasource.remote.SearchChatRemoteDataSource
+import com.kiwi.data.mapper.Mapper.toMarker
 import com.kiwi.domain.model.ChatInfo
 import com.kiwi.domain.model.Marker
 import com.kiwi.domain.repository.SearchChatRepository
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
 
-class SearchChatRepositoryImpl: SearchChatRepository {
-    override fun getMarkerList(keywords: List<String>, x: Double, y: Double): Flow<List<Marker>> {
-        TODO("Not yet implemented")
+class SearchChatRepositoryImpl @Inject constructor(
+    private val dataSource: SearchChatRemoteDataSource
+) : SearchChatRepository {
+    override suspend fun getMarkerList(
+        keywords: List<String>,
+        x: Double,
+        y: Double
+    ): Flow<Marker> = flow {
+        Log.d("SearchChatRepository", "getMarkerList: start flow")
+        dataSource.getMarkerList(keywords, x, y).collect() { markerRemote ->
+            Log.d("SearchChatRepository", "getMarkerList: $markerRemote")
+            emit(markerRemote.toMarker())
+        }
     }
 
-    override fun getChat(cid: String): ChatInfo {
+    override suspend fun getChat(cid: String): ChatInfo {
         TODO("Not yet implemented")
     }
 }

--- a/domain/src/main/java/com/kiwi/domain/repository/SearchChatRepository.kt
+++ b/domain/src/main/java/com/kiwi/domain/repository/SearchChatRepository.kt
@@ -5,7 +5,7 @@ import com.kiwi.domain.model.Marker
 import kotlinx.coroutines.flow.Flow
 
 interface SearchChatRepository {
-    fun getMarkerList(keywords: List<String>, x: Double, y: Double): Flow<List<Marker>>
+    suspend fun getMarkerList(keywords: List<String>, x: Double, y: Double): Flow<Marker>
 
-    fun getChat(cid: String): ChatInfo
+    suspend fun getChat(cid: String): ChatInfo
 }


### PR DESCRIPTION
# 작업 내용
- 지도에서 채팅방 찾는 화면(SearchChatFragment)에서 사용할 data, domain 모듈 구현
  - domain 모듈 SearchChatRepository의 함수 수정
  - data 모듈의 SearchChatRepositoryImpl의 함수 구현
  - data 모듈의 SearchChatDataSource의 인터페이스 및 클래스 구현
- 채팅방 목록 화면(ChatListFragment) 수정
  - 일부 이름 ChatList -> Chat 으로 변경
  - XML에서 DataBinding 방식 변경
  - 데이터가 없을 때 안내 문구 출력
  - 가운데 정렬 등 UI 수정

# TODO
- 채팅방 목록을 firestore에서 가져올 때 모든 데이터를 가져옴
  - query를 활용해 알맞은 데이터만 가져오도록 변경해야 함

Resolve #30