### PR TITLE
firestore에서 채팅방 목록 가져오기

### DIFF
--- a/app/src/main/java/com/kiwi/kiwitalk/ui/home/ChatListFragment.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/home/ChatListFragment.kt
@@ -80,4 +80,9 @@ class ChatListFragment : Fragment() {
             Log.d(TAG, "user: ${client.getCurrentUser()}")
         }
     }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        _binding = null
+    }
 }

--- a/app/src/main/java/com/kiwi/kiwitalk/ui/home/ChatListViewAdapter.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/home/ChatListViewAdapter.kt
@@ -6,7 +6,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import com.kiwi.kiwitalk.databinding.ChatItemBinding
+import com.kiwi.kiwitalk.databinding.ItemChatListBinding
 import io.getstream.chat.android.client.models.Channel
 
 class ChatListViewAdapter : ListAdapter<Channel, RecyclerView.ViewHolder>(ChatDiffUtil) {
@@ -14,7 +14,7 @@ class ChatListViewAdapter : ListAdapter<Channel, RecyclerView.ViewHolder>(ChatDi
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         return ChatViewHolder(
-            ChatItemBinding.inflate(
+            ItemChatListBinding.inflate(
                 LayoutInflater.from(
                     parent.context
                 ), parent, false
@@ -34,7 +34,7 @@ class ChatListViewAdapter : ListAdapter<Channel, RecyclerView.ViewHolder>(ChatDi
 
     }
 
-    class ChatViewHolder(private val binding: ChatItemBinding) :
+    class ChatViewHolder(private val binding: ItemChatListBinding) :
         RecyclerView.ViewHolder(binding.root) {
         fun bind(item: Channel) {
             Log.d("ChatListViewAdapter", "bind: ${item.image}")

--- a/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatActivity.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatActivity.kt
@@ -1,12 +1,59 @@
 package com.kiwi.kiwitalk.ui.search
 
-import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.OnMapReadyCallback
+import com.google.android.gms.maps.SupportMapFragment
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.MarkerOptions
 import com.kiwi.kiwitalk.R
+import com.kiwi.kiwitalk.databinding.ActivitySearchChatBinding
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
 
-class SearchChatActivity : AppCompatActivity() {
+@AndroidEntryPoint
+class SearchChatActivity : AppCompatActivity(), OnMapReadyCallback {
+    private val binding by lazy { ActivitySearchChatBinding.inflate(layoutInflater) }
+    private val viewModel: SearchChatViewModel by viewModels()
+    private lateinit var map: GoogleMap
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_search_chat)
+        setContentView(binding.root)
+        initMap()
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.markerList.collect {
+                    Log.d("SearchChatActivity", "onCreate: $it")
+                }
+            }
+        }
+        binding.tvSearchChatKeywords.setOnClickListener {
+            viewModel.getMarkerList(emptyList(), 0.0, 0.0)
+        } //TODO: FloatingButton 만들고 제거
+    }
+
+    private fun initMap() {
+        Log.d("SearchChatActivity", "initMap")
+        val mapFragment =
+            supportFragmentManager.findFragmentById(R.id.fragment_searchChat_map) as? SupportMapFragment
+        Log.d("SearchChatActivity", "mapFragment : $mapFragment")
+        mapFragment?.getMapAsync(this)
+    }
+
+    override fun onMapReady(_map: GoogleMap) {
+        Log.d(this::class.simpleName, "onMapReady: ")
+        map = _map
+        val seoul = LatLng(37.5666805, 126.9784147)
+        map.addMarker(
+            MarkerOptions().position(seoul).title("서울")
+        )
+        map.moveCamera(CameraUpdateFactory.newLatLngZoom(seoul, 10f))
     }
 }

--- a/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatViewModel.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatViewModel.kt
@@ -1,13 +1,33 @@
 package com.kiwi.kiwitalk.ui.search
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kiwi.domain.model.Marker
 import com.kiwi.domain.repository.SearchChatRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import io.getstream.chat.android.client.utils.toResult
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class SearchChatViewModel @Inject constructor(
     private val searchChatRepository: SearchChatRepository
 ) : ViewModel() {
+    private val _markerList = MutableSharedFlow<Marker>()
+    val markerList: SharedFlow<Marker> = _markerList
 
+    fun getMarkerList(keywords: List<String>, x: Double, y: Double) {
+        viewModelScope.launch {
+            searchChatRepository.getMarkerList(keywords, x, y)
+                .catch {
+                    Log.d("searchChatRepository", "getMarkerList: ${this.toResult()} $it")
+                }.collect {
+                    _markerList.emit(it)
+                }
+        }
+    }
 }

--- a/app/src/main/res/layout/activity_new_chat.xml
+++ b/app/src/main/res/layout/activity_new_chat.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ui.newchat.NewChatActivity"
-    >
+    tools:context=".ui.newchat.NewChatActivity">
 
     <fragment
         android:id="@+id/new_chat_nav_host"

--- a/app/src/main/res/layout/activity_search_chat.xml
+++ b/app/src/main/res/layout/activity_search_chat.xml
@@ -1,8 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".ui.search.SearchChatActivity">
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <androidx.appcompat.widget.LinearLayoutCompat
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/tv_searchChat_keywords"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingHorizontal="15dp"
+            android:paddingVertical="10dp"
+            android:text="마커 가져오기(임시)" />
+
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/fragment_searchChat_map"
+            android:name="com.google.android.gms.maps.SupportMapFragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </androidx.appcompat.widget.LinearLayoutCompat>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/fragment_chat_list.xml
+++ b/app/src/main/res/layout/fragment_chat_list.xml
@@ -12,7 +12,7 @@
         android:layout_height="match_parent"
         app:layoutManager="androidx.recyclerview.widget.StaggeredGridLayoutManager"
         app:spanCount="2"
-        tools:listitem="@layout/chat_item" />
+        tools:listitem="@layout/item_chat_list" />
 
     <TextView
         android:id="@+id/tv_chatList_empty"

--- a/app/src/main/res/layout/item_chat_list.xml
+++ b/app/src/main/res/layout/item_chat_list.xml
@@ -46,14 +46,14 @@
                 android:id="@+id/tv_rvChatList_country"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@{chat.extraData.getOrDefault(Const.MAP_KEY_COUNTRY, `지역`).toString()}"
+                android:text="@{chat.extraData.getOrDefault(Const.MAP_KEY_COUNTRY, @string/tv_itemChatList_country_default).toString()}"
                 tools:text="서울특별시 강남구" />
 
             <TextView
                 android:id="@+id/tv_rvChatList_keyword"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@{chat.extraData.getOrDefault(Const.MAP_KEY_KEYWORD, `키워드`).toString()}"
+                android:text="@{chat.extraData.getOrDefault(Const.MAP_KEY_KEYWORD, @string/tv_itemChatList_keyword_default).toString()}"
                 tools:text="축구, 농구, 운동" />
 
         </androidx.appcompat.widget.LinearLayoutCompat>

--- a/app/src/main/res/layout/item_chat_list.xml
+++ b/app/src/main/res/layout/item_chat_list.xml
@@ -24,7 +24,7 @@
             android:padding="10dp">
 
             <ImageView
-                android:id="@+id/img_chatList_profile"
+                android:id="@+id/img_rvChatList_profile"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
@@ -35,7 +35,7 @@
                 tools:src="@drawable/ic_launcher_background" />
 
             <TextView
-                android:id="@+id/tv_chat_title"
+                android:id="@+id/tv_rvChatList_chat_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:ellipsize="end"
@@ -43,14 +43,14 @@
                 tools:text="방 제목" />
 
             <TextView
-                android:id="@+id/tv_country"
+                android:id="@+id/tv_rvChatList_country"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@{chat.extraData.getOrDefault(Const.MAP_KEY_COUNTRY, `지역`).toString()}"
                 tools:text="서울특별시 강남구" />
 
             <TextView
-                android:id="@+id/tv_keyword"
+                android:id="@+id/tv_rvChatList_keyword"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@{chat.extraData.getOrDefault(Const.MAP_KEY_KEYWORD, `키워드`).toString()}"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,4 +17,6 @@
     <string name="img_chatList_profile_des">채팅방 이미지</string>
     <string name="tv_chatList_empty">참여한 채팅방이 없습니다.</string>
 
+    <string name="tv_itemChatList_country_default">지역</string>
+    <string name="tv_itemChatList_keyword_default">키워드</string>
 </resources>

--- a/data/src/main/java/com/kiwi/data/Const.kt
+++ b/data/src/main/java/com/kiwi/data/Const.kt
@@ -1,5 +1,5 @@
 package com.kiwi.data
 
 object Const {
-    const val CHAT_COLLECTION = "Chat"
+    const val CHAT_COLLECTION = "chat"
 }

--- a/data/src/main/java/com/kiwi/data/datasource/remote/SearchChatRemoteDataSource.kt
+++ b/data/src/main/java/com/kiwi/data/datasource/remote/SearchChatRemoteDataSource.kt
@@ -1,11 +1,11 @@
 package com.kiwi.data.datasource.remote
 
 import com.kiwi.data.model.remote.ChatInfoRemote
-import com.kiwi.data.model.remote.MarkerRemote
+import com.kiwi.domain.model.Marker
 import kotlinx.coroutines.flow.Flow
 
 interface SearchChatRemoteDataSource {
-    suspend fun getMarkerList(keyword: List<String>, x: Double, y: Double): Flow<MarkerRemote>
+    fun getMarkerList(keyword: List<String>, x: Double, y: Double): Flow<Marker>
 
     suspend fun getChat(cid: String): ChatInfoRemote
 }

--- a/data/src/main/java/com/kiwi/data/datasource/remote/SearchChatRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/kiwi/data/datasource/remote/SearchChatRemoteDataSourceImpl.kt
@@ -4,8 +4,10 @@ import android.util.Log
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ktx.toObjects
 import com.kiwi.data.Const
+import com.kiwi.data.mapper.Mapper.toMarker
 import com.kiwi.data.model.remote.ChatInfoRemote
 import com.kiwi.data.model.remote.MarkerRemote
+import com.kiwi.domain.model.Marker
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
@@ -14,17 +16,17 @@ import javax.inject.Inject
 class SearchChatRemoteDataSourceImpl @Inject constructor(
     private val firestore: FirebaseFirestore
 ) : SearchChatRemoteDataSource {
-    override suspend fun getMarkerList(
+    override fun getMarkerList(
         keyword: List<String>,
         x: Double,
         y: Double
-    ): Flow<MarkerRemote> = callbackFlow {
+    ): Flow<Marker> = callbackFlow {
         //TODO: Chat 컬렉션의 모든 데이터를 가져오지 않고, 쿼리를 사용하도록 변경
         firestore.collection(Const.CHAT_COLLECTION).get()
             .addOnSuccessListener {
                 Log.d("SearchChatRemoteImpl", "getMarkerList: ${it.documents}")
                 it.toObjects<MarkerRemote>().forEach { markerRemote ->
-                    trySend(markerRemote)
+                    trySend(markerRemote.toMarker())
                 }
             }.addOnFailureListener {
                 Log.d("SearchChatRemoteImpl", "getMarkerList: $it")

--- a/data/src/main/java/com/kiwi/data/repository/SearchChatRepositoryImpl.kt
+++ b/data/src/main/java/com/kiwi/data/repository/SearchChatRepositoryImpl.kt
@@ -2,7 +2,6 @@ package com.kiwi.data.repository
 
 import android.util.Log
 import com.kiwi.data.datasource.remote.SearchChatRemoteDataSource
-import com.kiwi.data.mapper.Mapper.toMarker
 import com.kiwi.domain.model.ChatInfo
 import com.kiwi.domain.model.Marker
 import com.kiwi.domain.repository.SearchChatRepository
@@ -13,15 +12,15 @@ import javax.inject.Inject
 class SearchChatRepositoryImpl @Inject constructor(
     private val dataSource: SearchChatRemoteDataSource
 ) : SearchChatRepository {
-    override suspend fun getMarkerList(
+    override fun getMarkerList(
         keywords: List<String>,
         x: Double,
         y: Double
     ): Flow<Marker> = flow {
         Log.d("SearchChatRepository", "getMarkerList: start flow")
-        dataSource.getMarkerList(keywords, x, y).collect() { markerRemote ->
-            Log.d("SearchChatRepository", "getMarkerList: $markerRemote")
-            emit(markerRemote.toMarker())
+        dataSource.getMarkerList(keywords, x, y).collect() { marker ->
+            Log.d("SearchChatRepository", "getMarkerList: $marker")
+            emit(marker)
         }
     }
 

--- a/domain/src/main/java/com/kiwi/domain/repository/SearchChatRepository.kt
+++ b/domain/src/main/java/com/kiwi/domain/repository/SearchChatRepository.kt
@@ -5,7 +5,7 @@ import com.kiwi.domain.model.Marker
 import kotlinx.coroutines.flow.Flow
 
 interface SearchChatRepository {
-    suspend fun getMarkerList(keywords: List<String>, x: Double, y: Double): Flow<Marker>
+    fun getMarkerList(keywords: List<String>, x: Double, y: Double): Flow<Marker>
 
     suspend fun getChat(cid: String): ChatInfo
 }


### PR DESCRIPTION
# 작업 내용
- SearchChat 관련 기능 구현 및 수정
  - domain, data 모듈의 함수 suspend 제거
  - MarkerRemote -> Marker 변환 위치 이동
  - ViewModel에서 데이터 채팅방 목록 불러오기
  - 채팅방 목록을 받아서 log에 출력
- 채팅방 목록 화면(ChatListFragment) 관련 리팩토링


# TODO
- firestore에서 채팅방 가져오는 버튼을 따로 만들지 않고 나중에 사용할 TextView에 ClickListener를 사용함
  - FloatingButton으로 바꿀 예정
- 쿼리를 사용해 데이터를 선택해 가져오도록 수정