### PR TITLE
로그인 실패 대응 추가

### DIFF
--- a/app/src/main/java/com/kiwi/kiwitalk/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/login/LoginActivity.kt
@@ -49,7 +49,13 @@ class LoginActivity : AppCompatActivity() {
             }
         )
 
-        skipLoginWhenTokenExist(viewModel.userId.value)
+        viewModel.loginState.observe(this){
+            if(it){
+                showPopUpMessage(LOGIN_SUCCESS)
+                navigateToHome()
+            }
+        }
+        viewModel.loginWithLocalToken()
 
         activityResultLauncher =
             registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
@@ -61,13 +67,6 @@ class LoginActivity : AppCompatActivity() {
         binding.btnGoogleSignup.setOnClickListener {
             val intent = viewModel.googleApiClient.signInIntent
             activityResultLauncher.launch(intent)
-        }
-    }
-
-    @RequiresApi(Build.VERSION_CODES.M)
-    private fun skipLoginWhenTokenExist(token: String?) {
-        if (!token.isNullOrEmpty()) {
-            loginWithLocalToken()
         }
     }
 
@@ -93,16 +92,9 @@ class LoginActivity : AppCompatActivity() {
             Log.d(TAG, e.toString())
         }
 
-        if (!viewModel.userId.value.isNullOrEmpty()) {
-            loginWithLocalToken()
+        if (viewModel.loginState.value == false) {
+            viewModel.loginWithLocalToken()
         }
-    }
-
-    @RequiresApi(Build.VERSION_CODES.M)
-    private fun loginWithLocalToken() {
-        viewModel.loginWithLocalToken()
-        showPopUpMessage(LOGIN_SUCCESS)
-        navigateToHome()
     }
 
     private fun navigateToHome() {

--- a/app/src/main/java/com/kiwi/kiwitalk/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/login/LoginViewModel.kt
@@ -8,14 +8,12 @@ import androidx.annotation.RequiresApi
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.google.android.gms.auth.api.signin.GoogleSignInClient
 import com.kiwi.kiwitalk.AppPreference
 import com.kiwi.kiwitalk.Const
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.User
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @RequiresApi(Build.VERSION_CODES.M)
@@ -29,12 +27,11 @@ class LoginViewModel @Inject constructor(
     var isNetworkConnect: Boolean = false
     var isReady: Boolean = false
 
-    private val _idToken = MutableLiveData<String>()
-    val userId: LiveData<String> = _idToken
+    private val _idToken = MutableLiveData<Boolean>(false)
+    val loginState: LiveData<Boolean> = _idToken
 
     init {
         isNetworkConnect = checkNetworkState()
-        loadLoginHistory()
         isReady = true
     }
 
@@ -54,33 +51,20 @@ class LoginViewModel @Inject constructor(
         }
     }
 
-
-    private fun loadLoginHistory() {
-        val savedToken = pref.getString(
-            Const.LOGIN_ID_KEY, Const.EMPTY_STRING
-        )
-        if (savedToken != Const.EMPTY_STRING) {
-            _idToken.value = savedToken
-            loginWithLocalToken()
-        }
-        Log.d("k001", "저장된 토큰 값 : $savedToken")
-        /* 기타 토큰 유효성 검사 추가 */
-    }
-
     fun saveToken(id: String, name: String, imageUrl: String) {
         /* pref에는 token만 넣기 */
         Log.d(LOCATION, "로그인 정보 저장 - token size : ${id.length}")
         pref.setString(Const.LOGIN_ID_KEY, id)
         pref.setString(Const.LOGIN_NAME_KEY, name)
         pref.setString(Const.LOGIN_URL_KEY, imageUrl)
-        _idToken.value = id
     }
 
-    fun loginWithLocalToken() {
+    fun loginWithLocalToken(){
         val savedToken = pref.getString(
             Const.LOGIN_ID_KEY, Const.EMPTY_STRING
         )
-        if (savedToken != Const.EMPTY_STRING) {
+
+        if (isValidToken(savedToken)) {
             val user = User(
                 id = pref.getString(Const.LOGIN_ID_KEY, Const.EMPTY_STRING),
                 name = pref.getString(Const.LOGIN_NAME_KEY, Const.EMPTY_STRING),
@@ -90,16 +74,24 @@ class LoginViewModel @Inject constructor(
             val token = chatClient.devToken(user.id)
             if (chatClient.getCurrentUser() == null) {
                 chatClient.connectUser(user, token).enqueue { result ->
-                    Log.d(LOCATION, "result is ${result.isSuccess}: $result")
+                    _idToken.value =  result.isSuccess
                 }
             } else {
                 Log.d(LOCATION, "user: ${chatClient.getCurrentUser()}")
+                _idToken.value = true
             }
+        } else {
+            pref.setString(Const.LOGIN_ID_KEY, Const.EMPTY_STRING)
+            _idToken.value = false
         }
-        Log.d("k001", "저장된 토큰 값 : $savedToken")
     }
 
-    companion object{
+    private fun isValidToken(token: String): Boolean{
+        return tokenRegex.matches(token)
+    }
+
+    companion object {
         private const val LOCATION = "k001"
+        private val tokenRegex = Regex("[0-9,a-z]{1,21}")
     }
 }

--- a/app/src/main/java/com/kiwi/kiwitalk/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/login/LoginViewModel.kt
@@ -27,8 +27,8 @@ class LoginViewModel @Inject constructor(
     var isNetworkConnect: Boolean = false
     var isReady: Boolean = false
 
-    private val _idToken = MutableLiveData<Boolean>(false)
-    val loginState: LiveData<Boolean> = _idToken
+    private val _loginState = MutableLiveData<Boolean>(false)
+    val loginState: LiveData<Boolean> = _loginState
 
     init {
         isNetworkConnect = checkNetworkState()
@@ -74,15 +74,15 @@ class LoginViewModel @Inject constructor(
             val token = chatClient.devToken(user.id)
             if (chatClient.getCurrentUser() == null) {
                 chatClient.connectUser(user, token).enqueue { result ->
-                    _idToken.value =  result.isSuccess
+                    _loginState.value =  result.isSuccess
                 }
             } else {
                 Log.d(LOCATION, "user: ${chatClient.getCurrentUser()}")
-                _idToken.value = true
+                _loginState.value = true
             }
         } else {
             pref.setString(Const.LOGIN_ID_KEY, Const.EMPTY_STRING)
-            _idToken.value = false
+            _loginState.value = false
         }
     }
 

--- a/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatActivity.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatActivity.kt
@@ -9,5 +9,6 @@ import dagger.hilt.android.AndroidEntryPoint
 class SearchChatActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_search_chat)
     }
 }

--- a/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatMapFragment.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatMapFragment.kt
@@ -37,7 +37,7 @@ import com.kiwi.kiwitalk.R
 import com.kiwi.kiwitalk.databinding.FragmentSearchChatMapBinding
 import com.kiwi.kiwitalk.model.ClusterMarker
 import com.kiwi.kiwitalk.model.ClusterMarker.Companion.toClusterMarker
-import com.kiwi.kiwitalk.ui.keyword.recyclerview.KeywordAdapter
+import com.kiwi.kiwitalk.ui.keyword.recyclerview.SelectedKeywordAdapter
 import com.kiwi.kiwitalk.ui.newchat.NewChatActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
@@ -80,18 +80,14 @@ class SearchChatMapFragment : Fragment() {
         viewModel.getMarkerList(37.0, 127.0)
         initBottomSheetCallBack()
 
-        /* TODO 마커 클릭으로 바꿔야함 */
         binding.fabCreateChat.setOnClickListener {
-            // newChatActivity로 바꾸는 코드로 대체해야함
-//            bottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
-//            viewModel.getPlaceInfo(Marker("messaging:-149653492", 1.0, 1.0, listOf()))
             startActivity(Intent(requireContext(), NewChatActivity::class.java))
         }
 
-        val adapter = KeywordAdapter(mutableListOf<Keyword>())
+        val adapter = SelectedKeywordAdapter()
         binding.layoutMarkerInfoPreview.rvChatKeywords.adapter = adapter
         viewModel.placeChatInfo.observe(viewLifecycleOwner) {
-            adapter.updateList(it.getPopularChat().keywords.map { Keyword(it, 0) }.toMutableList())
+            adapter.submitList(it.getPopularChat().keywords.map { Keyword(it, 0) }.toMutableList())
         }
     }
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -3,4 +3,5 @@
     <dimen name="bottomSheet_collapse_size">200dp</dimen>
     <dimen name="medium_margin">5dp</dimen>
     <dimen name="large_margin">10dp</dimen>
+    <dimen name="fab_margin">16dp</dimen>
 </resources>


### PR DESCRIPTION
- 토큰 바꾸기 전의 기기 데이터 때문에 login이 실패하는 경우가 있었다.
  - 토큰 유효성 검사 기준을 "" 이 아닌것 에서 숫자, 소문자 21글자 이내로 변경했다.
  - loginState라는 LiveDate를 옵저빙해서 UI를 변화시키도록 했다.

- 리뷰때 꼼꼼히 보지 않아서 오류가 생겼던 부분을 수정했다. 미리 로컬에서 머지시켜본 다음 리뷰를 해야겠다. 새삼 ide의 위대함을 느꼈다.