### PR TITLE
채팅방 검색 화면 리팩토링, 키워드 검색 화면과 데이터 연동, 마커 정보 표시 제거

### DIFF
--- a/app/src/main/java/com/kiwi/kiwitalk/model/ClusterMarker.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/model/ClusterMarker.kt
@@ -3,7 +3,6 @@ package com.kiwi.kiwitalk.model
 import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.clustering.ClusterItem
 import com.kiwi.domain.model.Marker
-import kotlin.random.Random
 
 data class ClusterMarker(
     val x: Double,
@@ -24,7 +23,7 @@ data class ClusterMarker(
 
     companion object {
         fun Marker.toClusterMarker(): ClusterMarker = ClusterMarker(
-            x = this.x + Random.nextDouble(0.1),
+            x = this.x,
             y = this.y,
             markerSnippet = cid,
             markerTitle = toString(),

--- a/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatMapFragment.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatMapFragment.kt
@@ -134,6 +134,15 @@ class SearchChatMapFragment : Fragment() {
                 }
             }
         }
+        clusterManager.markerCollection.setInfoWindowAdapter(object : InfoWindowAdapter {
+            override fun getInfoContents(p0: com.google.android.gms.maps.model.Marker): View {
+                return View(requireContext())
+            }
+
+            override fun getInfoWindow(p0: com.google.android.gms.maps.model.Marker): View {
+                return View(requireContext())
+            }
+        })
         map.setOnCameraIdleListener(clusterManager)
         setupMapClickListener(clusterManager)
     }

--- a/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatMapFragment.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatMapFragment.kt
@@ -235,8 +235,12 @@ class SearchChatMapFragment : Fragment() {
 
     override fun onDestroy() {
         super.onDestroy()
-        _binding = null
         bottomSheetBehavior.removeBottomSheetCallback(bottomSheetCallback)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
     companion object {

--- a/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatMapFragment.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatMapFragment.kt
@@ -113,9 +113,11 @@ class SearchChatMapFragment : Fragment() {
                 ?: return
         viewLifecycleOwner.lifecycleScope.launch {
             map = mapFragment.awaitMap()
+            map.clear()
             getDeviceLocation(permissions)
             setUpCluster()
         }
+        chatViewModel.getMarkerList(keywordViewModel.selectedKeyword.value)
         chatViewModel.location.observe(viewLifecycleOwner) {
             moveToLocation(it)
             chatViewModel.location.removeObservers(viewLifecycleOwner)

--- a/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatMapViewModel.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatMapViewModel.kt
@@ -2,12 +2,15 @@ package com.kiwi.kiwitalk.ui.search
 
 import android.location.Location
 import android.util.Log
+import androidx.core.location.component1
+import androidx.core.location.component2
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kiwi.domain.model.Marker
 import com.kiwi.domain.model.PlaceChatInfo
+import com.kiwi.domain.model.keyword.Keyword
 import com.kiwi.domain.repository.SearchChatRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.getstream.chat.android.client.utils.toResult
@@ -27,9 +30,6 @@ class SearchChatMapViewModel @Inject constructor(
     private val _placeChatInfo = MutableLiveData<PlaceChatInfo>()
     val placeChatInfo: LiveData<PlaceChatInfo> = _placeChatInfo
 
-    private val _keywords = MutableLiveData<List<String>>(listOf("축구", "카페"))
-    val keywords: LiveData<List<String>> = _keywords
-
     private val _location = MutableLiveData<Location>()
     val location: LiveData<Location> = _location
 
@@ -39,10 +39,11 @@ class SearchChatMapViewModel @Inject constructor(
         }
     }
 
-    fun getMarkerList(x: Double, y: Double) {
-        val keywords = keywords.value ?: return
+    fun getMarkerList(keywords: List<Keyword>?) {
+        if (keywords.isNullOrEmpty()) return
+        val (lat, lng) = location.value ?: return
         viewModelScope.launch {
-            searchChatRepository.getMarkerList(keywords, x, y)
+            searchChatRepository.getMarkerList(keywords, lat, lng)
                 .catch {
                     Log.d("SearchChatViewModel", "getMarkerList: ${this.toResult()} $it")
                 }.collect {

--- a/data/src/main/java/com/kiwi/data/repository/SearchChatRepositoryImpl.kt
+++ b/data/src/main/java/com/kiwi/data/repository/SearchChatRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.kiwi.data.datasource.remote.SearchChatRemoteDataSource
 import com.kiwi.domain.model.ChatInfo
 import com.kiwi.domain.model.Marker
 import com.kiwi.domain.model.PlaceChatInfo
+import com.kiwi.domain.model.keyword.Keyword
 import com.kiwi.domain.repository.SearchChatRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
@@ -14,12 +15,12 @@ class SearchChatRepositoryImpl @Inject constructor(
     private val dataSource: SearchChatRemoteDataSource,
 ) : SearchChatRepository {
     override fun getMarkerList(
-        keywords: List<String>,
+        keywords: List<Keyword>,
         x: Double,
         y: Double
     ): Flow<Marker> = flow {
         Log.d("SearchChatRepository", "getMarkerList: start flow")
-        dataSource.getMarkerList(keywords, x, y).collect() { marker ->
+        dataSource.getMarkerList(keywords.map { it.name }, x, y).collect() { marker ->
             Log.d("SearchChatRepository", "getMarkerList: $marker")
             emit(marker)
         }

--- a/domain/src/main/java/com/kiwi/domain/repository/SearchChatRepository.kt
+++ b/domain/src/main/java/com/kiwi/domain/repository/SearchChatRepository.kt
@@ -2,10 +2,11 @@ package com.kiwi.domain.repository
 
 import com.kiwi.domain.model.Marker
 import com.kiwi.domain.model.PlaceChatInfo
+import com.kiwi.domain.model.keyword.Keyword
 import kotlinx.coroutines.flow.Flow
 
 interface SearchChatRepository {
-    fun getMarkerList(keywords: List<String>, x: Double, y: Double): Flow<Marker>
+    fun getMarkerList(keywords: List<Keyword>, x: Double, y: Double): Flow<Marker>
 
     suspend fun getChat(marker: Marker): PlaceChatInfo
 }


### PR DESCRIPTION
# 작업 내용
- 채팅방 검색 화면
  - 변수 선언 방식 변경(lateinit -> 지역 변수, by lazy 등), 불필요한 전역변수 제거 등 리팩토링
  - 키워드를 사용해 마커를 불러올 때 전달하는 데이터 타입을 Keyword로 변경
    - Repository에서 Keyword -> String으로 매핑하도록 변경
  - 마커를 클릭했을 때 나오는 정보를 표시하지 않도록 변경
    - 바텀 시트로 대체


close #86 
