### PR TITLE
fix: 채팅방 목록 불러올 때 목록이 여러번 그려지는 버그 수정

### DIFF
--- a/app/src/main/java/com/kiwi/kiwitalk/ui/home/ChatListViewAdapter.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/home/ChatListViewAdapter.kt
@@ -53,7 +53,9 @@ class ChatListViewAdapter : ListAdapter<Channel, RecyclerView.ViewHolder>(ChatDi
             }
 
             override fun areContentsTheSame(oldItem: Channel, newItem: Channel): Boolean {
-                return oldItem == newItem
+                return oldItem.cid == newItem.cid && oldItem.createdAt == newItem.createdAt &&
+                        oldItem.hasUnread == newItem.hasUnread && oldItem.updatedAt == newItem.updatedAt &&
+                        oldItem.lastUpdated == newItem.lastUpdated && oldItem.unreadCount == newItem.unreadCount
             }
         }
     }


### PR DESCRIPTION
# 작업 내용
- 채팅방 목록 불러올 때 목록이 여러 번 그려지는 버그 수정


close #102 
