### PR TITLE
바텀시트 터치 버그 해결

### DIFF
--- a/app/src/main/java/com/kiwi/kiwitalk/ui/search/ChatAdapter.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/search/ChatAdapter.kt
@@ -11,7 +11,7 @@ import com.kiwi.kiwitalk.ui.keyword.recyclerview.SelectedKeywordAdapter
 class ChatAdapter(
     private var chatList: List<ChatInfo>?,
     private val chatClickListener: (ChatInfo) -> Unit
-) : RecyclerView.Adapter<ChatAdapter.ChatInfoViewHolder>() {
+) : RecyclerView.Adapter<ChatInfoViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ChatInfoViewHolder {
         val binding = ItemChatListNoImageBinding.inflate(LayoutInflater.from(parent.context))
@@ -23,7 +23,6 @@ class ChatAdapter(
         chatList?.let {
             val data = it[position]
             holder.bind(data)
-            // cid를 받아올 수 있는 방법이 기억 안나서 create 말고 bind에 넣음
             holder.binding.root.setOnClickListener {
                 chatClickListener(data)
             }
@@ -38,18 +37,4 @@ class ChatAdapter(
         chatList = list
         notifyDataSetChanged()
     }
-
-    inner class ChatInfoViewHolder(
-        val binding: ItemChatListNoImageBinding
-    ) : RecyclerView.ViewHolder(binding.root) {
-        fun bind(chatInfo: ChatInfo) {
-            binding.item = chatInfo
-            val adapter = SelectedKeywordAdapter()
-            binding.adapter = adapter
-            adapter.submitList(chatInfo.keywords.map {
-                Keyword(it, 0)
-            }.toMutableList())
-        }
-    }
-
 }

--- a/app/src/main/java/com/kiwi/kiwitalk/ui/search/ChatInfoViewHolder.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/search/ChatInfoViewHolder.kt
@@ -2,7 +2,7 @@ package com.kiwi.kiwitalk.ui.search
 
 import androidx.recyclerview.widget.RecyclerView
 import com.kiwi.domain.model.ChatInfo
-import com.kiwi.domain.model.keyword.Keyword
+import com.kiwi.domain.model.Keyword
 import com.kiwi.kiwitalk.databinding.ItemChatListNoImageBinding
 import com.kiwi.kiwitalk.ui.keyword.recyclerview.SelectedKeywordAdapter
 

--- a/app/src/main/java/com/kiwi/kiwitalk/ui/search/ChatInfoViewHolder.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/search/ChatInfoViewHolder.kt
@@ -1,0 +1,20 @@
+package com.kiwi.kiwitalk.ui.search
+
+import androidx.recyclerview.widget.RecyclerView
+import com.kiwi.domain.model.ChatInfo
+import com.kiwi.domain.model.keyword.Keyword
+import com.kiwi.kiwitalk.databinding.ItemChatListNoImageBinding
+import com.kiwi.kiwitalk.ui.keyword.recyclerview.SelectedKeywordAdapter
+
+class ChatInfoViewHolder(
+    val binding: ItemChatListNoImageBinding
+) : RecyclerView.ViewHolder(binding.root) {
+    fun bind(chatInfo: ChatInfo) {
+        binding.item = chatInfo
+        val adapter = SelectedKeywordAdapter()
+        binding.adapter = adapter
+        adapter.submitList(chatInfo.keywords.map {
+            Keyword(it, 0)
+        }.toMutableList())
+    }
+}

--- a/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatMapFragment.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatMapFragment.kt
@@ -12,7 +12,7 @@ import android.view.ViewGroup
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -57,7 +57,7 @@ class SearchChatMapFragment : Fragment(), ChatDialogAction {
             by lazy() { LocationServices.getFusedLocationProviderClient(requireActivity()) }
     private lateinit var map: GoogleMap
 
-    private lateinit var bottomSheetBehavior: BottomSheetBehavior<ConstraintLayout>
+    private lateinit var bottomSheetBehavior: BottomSheetBehavior<CoordinatorLayout>
     private lateinit var bottomSheetCallback: BottomSheetBehavior.BottomSheetCallback
 
     private val activityResultLauncher = initPermissionLauncher()
@@ -243,31 +243,35 @@ class SearchChatMapFragment : Fragment(), ChatDialogAction {
         bottomSheetCallback = object : BottomSheetBehavior.BottomSheetCallback() {
             override fun onStateChanged(bottomSheet: View, newState: Int) {
                 when (newState) {
-                    BottomSheetBehavior.STATE_DRAGGING -> {
-                        binding.layoutMarkerInfoPreview.rootLayout.visibility = View.GONE
-                        binding.rvDetail.visibility = View.VISIBLE
-                    }
-                    BottomSheetBehavior.STATE_COLLAPSED -> {
-                        binding.layoutMarkerInfoPreview.rootLayout.visibility = View.VISIBLE
-                        binding.rvDetail.visibility = View.INVISIBLE
-                    }
+                    BottomSheetBehavior.STATE_DRAGGING -> showBottomSheetDetail()
+                    BottomSheetBehavior.STATE_COLLAPSED -> showBottomSheetPreview()
                 }
             }
 
             override fun onSlide(bottomSheet: View, slideOffset: Float) {}
         }
 
-        bottomSheetBehavior = BottomSheetBehavior.from(binding.layoutBottomSheet)
-        bottomSheetBehavior.addBottomSheetCallback(bottomSheetCallback)
-        bottomSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
+        bottomSheetBehavior = BottomSheetBehavior
+            .from(binding.layoutBottomSheet)
+            .apply {
+                addBottomSheetCallback(bottomSheetCallback)
+                state = BottomSheetBehavior.STATE_HIDDEN
+                isDraggable = true
+                hideFriction = 0.01F
+                isFitToContents = true // default
+            }
     }
 
     private fun showBottomSheetDetail() {
-        binding.layoutMarkerInfoPreview.rootLayout.visibility = View.GONE
+        binding.layoutMarkerInfoPreview.rootLayout.visibility = View.INVISIBLE
+        binding.tvTmpChatDetail.visibility = View.VISIBLE
+        binding.rvDetail.visibility = View.VISIBLE
     }
 
     private fun showBottomSheetPreview() {
         binding.layoutMarkerInfoPreview.rootLayout.visibility = View.VISIBLE
+        binding.tvTmpChatDetail.visibility = View.INVISIBLE
+        binding.rvDetail.visibility = View.INVISIBLE
     }
 
     private fun initToolbar() {

--- a/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatMapFragment.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatMapFragment.kt
@@ -285,13 +285,9 @@ class SearchChatMapFragment : Fragment(), ChatDialogAction {
         binding.rvSearchChatKeywords.adapter = adapter
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-        bottomSheetBehavior.removeBottomSheetCallback(bottomSheetCallback)
-    }
-
     override fun onDestroyView() {
         super.onDestroyView()
+        bottomSheetBehavior.removeBottomSheetCallback(bottomSheetCallback)
         _binding = null
     }
 

--- a/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatMapFragment.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/search/SearchChatMapFragment.kt
@@ -262,6 +262,14 @@ class SearchChatMapFragment : Fragment(), ChatDialogAction {
         bottomSheetBehavior.state = BottomSheetBehavior.STATE_HIDDEN
     }
 
+    private fun showBottomSheetDetail() {
+        binding.layoutMarkerInfoPreview.rootLayout.visibility = View.GONE
+    }
+
+    private fun showBottomSheetPreview() {
+        binding.layoutMarkerInfoPreview.rootLayout.visibility = View.VISIBLE
+    }
+
     private fun initToolbar() {
         binding.searchChatMapToolbar.setNavigationOnClickListener {
             activity?.finish()

--- a/app/src/main/res/layout/fragment_search_chat_map.xml
+++ b/app/src/main/res/layout/fragment_search_chat_map.xml
@@ -78,6 +78,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_gravity="bottom"
+            android:clickable="true"
             android:elevation="7dp"
             app:behavior_hideable="true"
             app:behavior_peekHeight="@dimen/bottomSheet_collapse_size"

--- a/app/src/main/res/layout/fragment_search_chat_map.xml
+++ b/app/src/main/res/layout/fragment_search_chat_map.xml
@@ -16,7 +16,7 @@
         android:layout_height="match_parent"
         tools:context=".ui.search.SearchChatMapFragment">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <androidx.coordinatorlayout.widget.CoordinatorLayout
             android:id="@+id/layout_bottomSheet"
             style="@style/Widget.MaterialComponents.BottomSheet"
             android:layout_width="match_parent"
@@ -39,21 +39,29 @@
             <include
                 android:id="@+id/layout_markerInfo_preview"
                 layout="@layout/view_marker_preview"
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="@dimen/bottomSheet_collapse_size"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
                 bind:item="@{vm.placeChatInfo}" />
+
+            <TextView
+                android:id="@+id/tv_tmp_chatDetail"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:padding="@dimen/medium_margin"
+                android:text="채팅방 더보기"
+                android:textSize="30sp"
+                android:visibility="invisible" />
 
             <androidx.recyclerview.widget.RecyclerView
                 android:id="@+id/rv_detail"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/layout_markerInfo_preview" />
+                android:layout_gravity="bottom"
+                app:layout_anchor="@id/tv_tmp_chatDetail"
+                app:layout_anchorGravity="bottom" />
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.coordinatorlayout.widget.CoordinatorLayout>
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_search_chat_map.xml
+++ b/app/src/main/res/layout/fragment_search_chat_map.xml
@@ -17,6 +17,45 @@
         tools:context=".ui.search.SearchChatMapFragment">
 
         <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/layout_bottomSheet"
+            style="@style/Widget.MaterialComponents.BottomSheet"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_gravity="bottom"
+            android:clickable="true"
+            android:elevation="7dp"
+            android:focusable="true"
+            app:behavior_hideable="true"
+            app:behavior_peekHeight="@dimen/bottomSheet_collapse_size"
+            app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
+
+            <!-- Drag handle for accessibility -->
+            <com.google.android.material.bottomsheet.BottomSheetDragHandleView
+                android:id="@+id/drag_handle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <include
+                android:id="@+id/layout_markerInfo_preview"
+                layout="@layout/view_marker_preview"
+                android:layout_width="0dp"
+                android:layout_height="@dimen/bottomSheet_collapse_size"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                bind:item="@{vm.placeChatInfo}" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rv_detail"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/layout_markerInfo_preview" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
@@ -72,42 +111,5 @@
             android:contentDescription="@string/new_chat_description"
             android:src="@drawable/ic_search_chat_new_chat" />
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/layout_bottomSheet"
-            style="@style/Widget.MaterialComponents.BottomSheet"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_gravity="bottom"
-            android:clickable="true"
-            android:elevation="7dp"
-            app:behavior_hideable="true"
-            app:behavior_peekHeight="@dimen/bottomSheet_collapse_size"
-            app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
-
-            <!-- Drag handle for accessibility -->
-            <com.google.android.material.bottomsheet.BottomSheetDragHandleView
-                android:id="@+id/drag_handle"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <include
-                android:id="@+id/layout_markerInfo_preview"
-                layout="@layout/view_marker_preview"
-                android:layout_width="0dp"
-                android:layout_height="@dimen/bottomSheet_collapse_size"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                bind:item="@{vm.placeChatInfo}" />
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/rv_detail"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/layout_markerInfo_preview" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>

--- a/app/src/main/res/layout/view_marker_preview.xml
+++ b/app/src/main/res/layout/view_marker_preview.xml
@@ -10,7 +10,7 @@
             type="com.kiwi.domain.model.PlaceChatInfo" />
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:id="@+id/root_layout"
         android:layout_width="match_parent"
         android:layout_height="@dimen/bottomSheet_collapse_size"
@@ -20,33 +20,32 @@
             android:id="@+id/rv_preview_chat"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            android:orientation="vertical" />
 
         <TextView
             android:id="@+id/tv_chat_location"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
             android:layout_marginVertical="@dimen/large_margin"
             android:text="@{item.popularChat.address}"
             android:textColor="?attr/colorOnSurface"
             android:textStyle="bold"
-            app:layout_constraintStart_toStartOf="@id/rv_preview_chat"
-            app:layout_constraintTop_toBottomOf="@id/rv_preview_chat"
+            app:layout_anchor="@id/rv_preview_chat"
+            app:layout_anchorGravity="start|bottom"
             tools:text="청주시 청원구" />
 
         <TextView
             android:id="@+id/tv_chat_number_prefix"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
             android:layout_margin="@dimen/large_margin"
             android:text="@{@string/chat_number(item.chattingNumber)}"
             android:textColor="?attr/colorOnSurfaceVariant"
             android:textStyle="bold"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/rv_preview_chat"
+            app:layout_anchor="@id/rv_preview_chat"
+            app:layout_anchorGravity="end|bottom"
             tools:text="현재 채팅방 수 : 5" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </layout>

--- a/data/src/main/java/com/kiwi/data/mapper/Mapper.kt
+++ b/data/src/main/java/com/kiwi/data/mapper/Mapper.kt
@@ -1,7 +1,7 @@
 package com.kiwi.data.mapper
 
 import com.kiwi.data.Const
-import com.kiwi.data.mapper.DateFormatter.formatTimeString
+import com.kiwi.data.mapper.StringFormatter.formatTimeString
 import com.kiwi.data.model.remote.MarkerRemote
 import com.kiwi.data.model.remote.NewChatRemote
 import com.kiwi.data.model.remote.PlaceListRemote
@@ -43,7 +43,7 @@ object Mapper {
         description = this.extraData["description"] as? String ?: "",
         memberCount = this.memberCount,
         lastMessageAt = this.lastMessageAt?.formatTimeString() ?: "오래전",
-        address = DateFormatter.trimAddress(this.extraData[Const.MAP_KEY_ADDRESS])
+        address = StringFormatter.trimAddress(this.extraData[Const.MAP_KEY_ADDRESS])
     )
 
     fun NewChatInfo.toNewChatRemote() = NewChatRemote(

--- a/data/src/main/java/com/kiwi/data/mapper/StringFormatter.kt
+++ b/data/src/main/java/com/kiwi/data/mapper/StringFormatter.kt
@@ -3,7 +3,7 @@ package com.kiwi.data.mapper
 import com.kiwi.data.Const.SPACE
 import java.util.*
 
-object DateFormatter {
+object StringFormatter {
     private const val SEC = 60
     private const val MIN = 60
     private const val HOUR = 24
@@ -15,7 +15,7 @@ object DateFormatter {
         val curTime = System.currentTimeMillis()
 
         var diffTime = (curTime - regTime) / 1000
-        var msg: String = ""
+        var msg = ""
         if (diffTime < SEC) {
             msg = "방금 전"
         } else if (SEC.let { diffTime /= it; diffTime } < MIN) {


### PR DESCRIPTION
### UI 변경
- 채팅방 상세 정보 위에 텍스트뷰 추가

### 구현 변경  
- 바텀시트에 들어가는 모든 뷰를 CoordinatorLayout으로 변경함
   - RecyclerView가 바텀시트로 전달되어야할 터치를 막아서 발생한 버그여서 이게 해결책이 되었음
- 바텀시트의 clickable 속성을 true로 설정
- ViewHolder를 inner class에서 일반 class로 변경함