### PR TITLE
유저 정보 singleton으로 관리하도록 수정

### DIFF
--- a/app/src/main/java/com/kiwi/kiwitalk/ui/home/ProfileViewModel.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/home/ProfileViewModel.kt
@@ -8,18 +8,17 @@ import androidx.lifecycle.ViewModel
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.storage.ktx.storage
 import com.kiwi.domain.model.Keyword
+import com.kiwi.domain.model.UserInfo
+import com.kiwi.domain.repository.UserRepository
+import com.kiwi.kiwitalk.util.Const
 import dagger.hilt.android.lifecycle.HiltViewModel
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.User
 import javax.inject.Inject
 
-
-/**
- * 너무나 단순한 작업에서 MVVM구조를 따라야할까?
- */
 @HiltViewModel
 class ProfileViewModel @Inject constructor(
-    val chatClient: ChatClient
+    private val userRepository: UserRepository,
 ) : ViewModel() {
     private val _profileImage = MutableLiveData<String?>()
     val profileImage: LiveData<String?> = _profileImage
@@ -35,15 +34,11 @@ class ProfileViewModel @Inject constructor(
         getMyProfile()
     }
 
-    fun getMyProfile() {
-        chatClient.getCurrentUser()?.let { user ->
-            myName.value = user.name
-            user.extraData.get("keywords")?.let { keywordStringList ->
-                _myKeywords.value = (keywordStringList as List<*>).map { keywordString ->
-                    Keyword(keywordString as String)
-                }
-            }
-            _profileImage.value = user.image.ifBlank { null }
+    private fun getMyProfile() {
+        userRepository.getUserInfo().let { userInfo ->
+            myName.value = userInfo.name
+            _myKeywords.value = userInfo.keywords
+            _profileImage.value = userInfo.imageUrl.ifBlank { null }
         }
     }
 
@@ -54,32 +49,38 @@ class ProfileViewModel @Inject constructor(
     }
 
     fun setUpdateProfile() {
-        chatClient.getCurrentUser()?.let { user ->
-            myName.value?.let { myNameString ->
-                user.name = myNameString
-            }
-            myKeywords.value?.let { myKeywordsList ->
-                user.extraData.put("keywords", myKeywordsList.map { it.name })
-            }
-            val uri = profileImage.value
-            if (uri == null) {
-                updateUser(user, uri)
-            } else {
-                val ref = Firebase.storage.reference.child("profile/${user.id}")
-                ref.putFile(Uri.parse(uri)).addOnSuccessListener {
-                    it.storage.downloadUrl.addOnCompleteListener { url ->
-                        updateUser(user, url.result.toString())
-                    }
-                }.addOnFailureListener {
-                    Log.d("NewChatDataSource", "putFile Failure: $it")
+        val uri = profileImage.value
+        val id = userRepository.getUserInfo().id
+        if (uri == null) {
+            updateUser(
+                UserInfo(
+                    id = id,
+                    name = myName.value ?: Const.EMPTY_STRING,
+                    keywords = myKeywords.value ?: listOf(),
+                    imageUrl = Const.EMPTY_STRING
+                )
+            )
+        } else {
+            val ref = Firebase.storage.reference.child("profile/${id}")
+            ref.putFile(Uri.parse(uri)).addOnSuccessListener {
+                it.storage.downloadUrl.addOnCompleteListener { url ->
+                    updateUser(
+                        UserInfo(
+                            id = id,
+                            name = myName.value ?: Const.EMPTY_STRING,
+                            keywords = myKeywords.value ?: listOf(),
+                            imageUrl = url.result.toString()
+                        )
+                    )
                 }
+            }.addOnFailureListener {
+                Log.d("NewChatDataSource", "putFile Failure: $it")
             }
         }
     }
 
-    private fun updateUser(user: User, uri: String?) {
-        user.image = uri ?: ""
-        chatClient.updateUser(user).enqueue()
+    private fun updateUser(userInfo: UserInfo) {
+        userRepository.updateUser(userInfo)
     }
 
     fun setChatImage(uri: String) {

--- a/app/src/main/java/com/kiwi/kiwitalk/ui/newchat/NewChatViewModel.kt
+++ b/app/src/main/java/com/kiwi/kiwitalk/ui/newchat/NewChatViewModel.kt
@@ -8,6 +8,7 @@ import com.google.android.gms.maps.model.LatLng
 import com.kiwi.domain.model.NewChatInfo
 import com.kiwi.domain.repository.NewChatRepository
 import com.kiwi.data.AppPreference
+import com.kiwi.domain.repository.UserRepository
 import com.kiwi.kiwitalk.util.Const.EMPTY_STRING
 import com.kiwi.kiwitalk.util.Const.LOGIN_ID_KEY
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -17,7 +18,7 @@ import javax.inject.Inject
 @HiltViewModel
 class NewChatViewModel @Inject constructor(
     private val repository: NewChatRepository,
-    private val pref: AppPreference
+    private val userRepository: UserRepository,
 ) : ViewModel() {
 
     private val _chatImage = MutableLiveData<String>()
@@ -53,7 +54,7 @@ class NewChatViewModel @Inject constructor(
     }
 
     fun setChatId() {
-        _chatId.value = pref.getString(LOGIN_ID_KEY, EMPTY_STRING)
+        _chatId.value = userRepository.getUserInfo().id
     }
 
     fun addNewChat(userid: String, currentTime: String, newChat: NewChatInfo) {

--- a/data/src/main/java/com/kiwi/data/datasource/remote/UserRemoteDataSource.kt
+++ b/data/src/main/java/com/kiwi/data/datasource/remote/UserRemoteDataSource.kt
@@ -8,4 +8,5 @@ interface UserRemoteDataSource {
     fun login(token: String, callback: UserDataCallback)
     fun updateUser(user: User)
     suspend fun signOut(): Flow<Boolean>
+    fun getCurrentUser(): User?
 }

--- a/data/src/main/java/com/kiwi/data/datasource/remote/UserRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/kiwi/data/datasource/remote/UserRemoteDataSourceImpl.kt
@@ -45,4 +45,8 @@ class UserRemoteDataSourceImpl @Inject constructor(
         }
         awaitClose()
     }
+
+    override fun getCurrentUser(): User? {
+        return chatClient.getCurrentUser()
+    }
 }

--- a/data/src/main/java/com/kiwi/data/mapper/Mapper.kt
+++ b/data/src/main/java/com/kiwi/data/mapper/Mapper.kt
@@ -41,7 +41,7 @@ object Mapper {
     fun Channel.toChatInfo() = ChatInfo(
         cid = this.cid,
         name = this.name,
-        keywords = this.extraData[Const.MAP_KEY_KEYWORD] as? List<String>? ?: listOf("키워드가 없습니다"),
+        keywords = this.extraData[Const.MAP_KEY_KEYWORD] as? List<String>? ?: listOf(),
         description = this.extraData["description"] as? String ?: "",
         memberCount = this.memberCount,
         lastMessageAt = this.lastMessageAt?.formatTimeString() ?: Const.EMPTY_STRING,

--- a/data/src/main/java/com/kiwi/data/mapper/Mapper.kt
+++ b/data/src/main/java/com/kiwi/data/mapper/Mapper.kt
@@ -70,4 +70,14 @@ object Mapper {
             }
         )
     }
+
+    fun UserInfo.toUser(): User {
+        val user = User(
+            id = this.id,
+            name = this.name,
+            image = this.imageUrl
+        )
+        user.extraData.put(Const.MAP_KEY_KEYWORD, this.keywords.map { it.name })
+        return user
+    }
 }

--- a/data/src/main/java/com/kiwi/data/mapper/Mapper.kt
+++ b/data/src/main/java/com/kiwi/data/mapper/Mapper.kt
@@ -1,6 +1,7 @@
 package com.kiwi.data.mapper
 
 import com.kiwi.data.Const
+import com.kiwi.data.mapper.Mapper.toChatInfo
 import com.kiwi.data.mapper.StringFormatter.formatTimeString
 import com.kiwi.data.model.remote.MarkerRemote
 import com.kiwi.data.model.remote.NewChatRemote
@@ -8,6 +9,7 @@ import com.kiwi.data.model.remote.PlaceListRemote
 import com.kiwi.data.model.remote.PlaceRemote
 import com.kiwi.domain.model.*
 import io.getstream.chat.android.client.models.Channel
+import io.getstream.chat.android.client.models.User
 
 object Mapper {
     fun MarkerRemote.toMarker() = Marker(
@@ -56,4 +58,16 @@ object Mapper {
         lat = this.lat,
         lng = this.lng
     )
+
+
+    fun User.toUserInfo(): UserInfo {
+        val keywordStringList = this.extraData[Const.MAP_KEY_KEYWORD] as? List<String>? ?: listOf()
+        return UserInfo(
+            this.id,
+            this.name,
+            keywordStringList.map {
+                Keyword(it)
+            }
+        )
+    }
 }

--- a/data/src/main/java/com/kiwi/data/mapper/Mapper.kt
+++ b/data/src/main/java/com/kiwi/data/mapper/Mapper.kt
@@ -63,11 +63,12 @@ object Mapper {
     fun User.toUserInfo(): UserInfo {
         val keywordStringList = this.extraData[Const.MAP_KEY_KEYWORD] as? List<String>? ?: listOf()
         return UserInfo(
-            this.id,
-            this.name,
-            keywordStringList.map {
+            id = this.id,
+            name = this.name,
+            keywords = keywordStringList.map {
                 Keyword(it)
-            }
+            },
+            imageUrl = image,
         )
     }
 

--- a/data/src/main/java/com/kiwi/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/kiwi/data/repository/UserRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.kiwi.data.repository
 import com.kiwi.data.UserDataCallback
 import com.kiwi.data.datasource.local.UserLocalDataSource
 import com.kiwi.data.datasource.remote.UserRemoteDataSource
+import com.kiwi.data.mapper.Mapper.toUser
 import com.kiwi.data.mapper.Mapper.toUserInfo
 import com.kiwi.domain.UserUiCallback
 import com.kiwi.domain.model.UserInfo
@@ -89,7 +90,13 @@ class UserRepositoryImpl @Inject constructor(
         userRemoteDataSource.getCurrentUser()?.let {
             lastUser = it.toUserInfo()
         }
-        return lastUser
+        return lastUser.copy()
+    }
+
+    override fun updateUser(userInfo: UserInfo) {
+        userRemoteDataSource.updateUser(
+            userInfo.toUser()
+        )
     }
 
     companion object {

--- a/data/src/main/java/com/kiwi/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/kiwi/data/repository/UserRepositoryImpl.kt
@@ -3,7 +3,9 @@ package com.kiwi.data.repository
 import com.kiwi.data.UserDataCallback
 import com.kiwi.data.datasource.local.UserLocalDataSource
 import com.kiwi.data.datasource.remote.UserRemoteDataSource
+import com.kiwi.data.mapper.Mapper.toUserInfo
 import com.kiwi.domain.UserUiCallback
+import com.kiwi.domain.model.UserInfo
 import com.kiwi.domain.repository.UserRepository
 import io.getstream.chat.android.client.models.User
 import kotlinx.coroutines.flow.Flow
@@ -81,10 +83,18 @@ class UserRepositoryImpl @Inject constructor(
         return tokenRegex.matches(token)
     }
 
+    override fun getUserInfo(): UserInfo {
+        userRemoteDataSource.getCurrentUser()?.let {
+            lastUser = it.toUserInfo()
+        }
+        return lastUser
+    }
+
     companion object {
         private const val TAG = "k001|UserRepo"
         private val tokenRegex = Regex("[0-9,a-z]{1,21}")
         private val INVALID_TOKEN = Exception("Invalid Token")
         private val NO_DATA = Exception("Stream에서 Id값이 Empty String으로 반환됨")
+        private var lastUser: UserInfo = UserInfo("","", listOf())
     }
 }

--- a/data/src/main/java/com/kiwi/data/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/kiwi/data/repository/UserRepositoryImpl.kt
@@ -58,8 +58,10 @@ class UserRepositoryImpl @Inject constructor(
                         userRemoteDataSource.updateUser(
                             User(id = this.id, name = googleName, image = imageUrl)
                         )
+                        lastUser = UserInfo(this.id, googleName, listOf())
                     } else {
                         userLocalDataSource.saveToken(id, name, image)
+                        lastUser = this.toUserInfo()
                     }
                 }
                 userUiCallback.onSuccess()

--- a/domain/src/main/java/com/kiwi/domain/model/UserInfo.kt
+++ b/domain/src/main/java/com/kiwi/domain/model/UserInfo.kt
@@ -4,4 +4,5 @@ data class UserInfo(
     val id: String,
     val name: String,
     val keywords : List<Keyword>,
+    val imageUrl: String = ""
 )

--- a/domain/src/main/java/com/kiwi/domain/model/UserInfo.kt
+++ b/domain/src/main/java/com/kiwi/domain/model/UserInfo.kt
@@ -1,0 +1,7 @@
+package com.kiwi.domain.model
+
+data class UserInfo(
+    val id: String,
+    val name: String,
+    val keywords : List<Keyword>,
+)

--- a/domain/src/main/java/com/kiwi/domain/repository/UserRepository.kt
+++ b/domain/src/main/java/com/kiwi/domain/repository/UserRepository.kt
@@ -1,6 +1,7 @@
 package com.kiwi.domain.repository
 
 import com.kiwi.domain.UserUiCallback
+import com.kiwi.domain.model.UserInfo
 import kotlinx.coroutines.flow.Flow
 
 interface UserRepository {
@@ -9,4 +10,5 @@ interface UserRepository {
         token: String, googleName: String, imageUrl: String, userUiCallback: UserUiCallback
     )
     suspend fun signOut(): Flow<Boolean>
+    fun getUserInfo(): UserInfo
 }

--- a/domain/src/main/java/com/kiwi/domain/repository/UserRepository.kt
+++ b/domain/src/main/java/com/kiwi/domain/repository/UserRepository.kt
@@ -11,4 +11,5 @@ interface UserRepository {
     )
     suspend fun signOut(): Flow<Boolean>
     fun getUserInfo(): UserInfo
+    fun updateUser(userInfo: UserInfo)
 }


### PR DESCRIPTION
**코드 수정 내용**
- UserRepository의 companion object에 lastUserInfo를 추가해서 캐시로 사용함
- 유저 정보를 넘겨줄 때 우선 `chatClient.getCurrentUser`를 사용하고, 여기서 null이 반환된다면 캐시된 lastUserInfo를 반환하도록 함
- presentation layer에서는 UserInfo 모델을, data layer에서는 User 모델을 사용하도록 함